### PR TITLE
fix(numbers): crash when parsing floating point without whole number

### DIFF
--- a/src/commonMain/kotlin/nl/jacobras/humanreadable/HumanReadableNumber.kt
+++ b/src/commonMain/kotlin/nl/jacobras/humanreadable/HumanReadableNumber.kt
@@ -33,7 +33,7 @@ internal fun Double.formatNumber(
 
 private fun Double.formatWithDecimals(decimals: Int): String {
     val multiplier = 10.0.pow(decimals)
-    val numberAsString = (this * multiplier).roundToLong().toString()
+    val numberAsString = (this * multiplier).roundToLong().toString().padStart(decimals + 1, '0')
     val decimalIndex = numberAsString.length - decimals - 1
     val mainRes = numberAsString.substring(0..decimalIndex)
     val fractionRes = numberAsString.substring(decimalIndex + 1)

--- a/src/commonTest/kotlin/nl/jacobras/humanreadable/HumanReadableNumberEdgeCaseTests.kt
+++ b/src/commonTest/kotlin/nl/jacobras/humanreadable/HumanReadableNumberEdgeCaseTests.kt
@@ -1,0 +1,18 @@
+package nl.jacobras.humanreadable
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import io.github.skeptick.libres.LibresSettings
+import kotlin.test.Test
+
+class HumanReadableNumberEdgeCaseTests {
+    init {
+        LibresSettings.languageCode = "en"
+    }
+
+    @Test
+    fun floatingPointWithoutWholeNumber() {
+        assertThat(HumanReadable.number(0.04, decimals = 2)).isEqualTo("0.04")
+        assertThat(HumanReadable.number(00000.00004, decimals = 3)).isEqualTo("0.000")
+    }
+}


### PR DESCRIPTION
## Issue
- Previously, crash when passing floating point numbers without whole number (Example, `0.04`) with `IndexOutOfBound` exception

## Fix
- Add `padStart` to ensure zeros are padding correctly