### PR TITLE
Fix `Res` object in root

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,3 +105,7 @@ tasks.withType<AbstractPublishToMaven>().configureEach {
     val signingTasks = tasks.withType<Sign>()
     mustRunAfter(signingTasks)
 }
+
+libres {
+    generatedClassName = "HumanReadableRes"
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "nl.jacobras"
-version = "1.10.0"
+version = "1.10.1"
 
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.S01, true)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.compose.compiler) apply false
     id("com.vanniktech.maven.publish") version "0.30.0"
-    id("io.github.skeptick.libres") version "1.2.3-beta02" // Beta includes WASM support
+    id("io.github.skeptick.libres") version "1.2.3"
 }
 
 group = "nl.jacobras"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.1.0"
+kotlin = "2.1.10"
 compose-plugin = "1.7.3"
 
 [libraries]

--- a/src/commonMain/kotlin/nl/jacobras/humanreadable/HumanReadableFileSize.kt
+++ b/src/commonMain/kotlin/nl/jacobras/humanreadable/HumanReadableFileSize.kt
@@ -1,6 +1,6 @@
 package nl.jacobras.humanreadable
 
-import Res
+import HumanReadableRes as Res
 
 /**
  * Returns the given [bytes] size in human-readable format.

--- a/src/commonMain/kotlin/nl/jacobras/humanreadable/HumanReadableNumber.kt
+++ b/src/commonMain/kotlin/nl/jacobras/humanreadable/HumanReadableNumber.kt
@@ -1,6 +1,6 @@
 package nl.jacobras.humanreadable
 
-import Res
+import HumanReadableRes as Res
 import kotlin.math.pow
 import kotlin.math.roundToLong
 

--- a/src/commonMain/kotlin/nl/jacobras/humanreadable/HumanReadableRelativeTime.kt
+++ b/src/commonMain/kotlin/nl/jacobras/humanreadable/HumanReadableRelativeTime.kt
@@ -1,6 +1,6 @@
 package nl.jacobras.humanreadable
 
-import Res
+import HumanReadableRes as Res
 import kotlinx.datetime.Instant
 
 /**

--- a/src/commonMain/kotlin/nl/jacobras/humanreadable/TimeUnit.kt
+++ b/src/commonMain/kotlin/nl/jacobras/humanreadable/TimeUnit.kt
@@ -1,7 +1,7 @@
 package nl.jacobras.humanreadable
 
-import Res
 import io.github.skeptick.libres.strings.VoidPluralString
+import HumanReadableRes as Res
 
 internal enum class TimeUnit(
     val past: () -> VoidPluralString,

--- a/src/commonMain/libres/strings/time_units_nl.xml
+++ b/src/commonMain/libres/strings/time_units_nl.xml
@@ -10,7 +10,7 @@
     </plurals>
     <plurals name="hours">
         <item quantity="one">uur</item>
-        <item quantity="other">uren</item>
+        <item quantity="other">uur</item>
     </plurals>
     <plurals name="days">
         <item quantity="one">dag</item>


### PR DESCRIPTION
Unfortunately, Libres doesn't allow:
* setting a package
* changing visibility

So this PR just changes the generated `Res` to `HumanReadableRes`, so it won't collide with consuming projects' internal `Res` objects anymore.

Fixes #92