### PR TITLE
Update `kotlinx.datetime` to version `0.7.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ This library only supports [kotlinx-datetime](https://github.com/Kotlin/kotlinx-
 
 The library is published to Maven Central.
 
+**Note:** HumanReadable 1.12.0 requires kotlinx-datetime 0.7+, see https://github.com/jacobras/Human-Readable/issues/148.
+
 ```kotlin
 dependencies {
-    implementation("nl.jacobras:Human-Readable:1.11.0")
+    implementation("nl.jacobras:Human-Readable:1.12.0")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "nl.jacobras"
-version = "1.11.0"
+version = "1.12.0"
 
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.S01, true)

--- a/demo/src/jsMain/kotlin/ui/TimeDemo.kt
+++ b/demo/src/jsMain/kotlin/ui/TimeDemo.kt
@@ -16,10 +16,13 @@ import kotlinx.datetime.*
 import monoBodyOrange
 import monoBodyStringBold
 import nl.jacobras.humanreadable.HumanReadable
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
-@OptIn(ExperimentalLayoutApi::class)
+@OptIn(ExperimentalLayoutApi::class, ExperimentalTime::class)
 @Composable
 internal fun TimeDemo(
     selectedLanguageCode: String,
@@ -113,6 +116,7 @@ internal fun TimeDemo(
     }
 }
 
+@OptIn(ExperimentalTime::class)
 @Composable
 private fun DateTimeField(instant: Instant, onUpdate: (Instant) -> Unit) {
     var error by remember { mutableStateOf(false) }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ compose-plugin = "1.7.3"
 
 [libraries]
 assertK = { module = "com.willowtreeapps.assertk:assertk", version = "0.28.1" }
-kotlinX-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.6.2" }
+kotlinX-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.7.0" }
 
 [plugins]
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/src/commonMain/kotlin/nl/jacobras/humanreadable/HumanReadable.kt
+++ b/src/commonMain/kotlin/nl/jacobras/humanreadable/HumanReadable.kt
@@ -2,11 +2,12 @@
 
 package nl.jacobras.humanreadable
 
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import nl.jacobras.humanreadable.HumanReadable.duration
 import nl.jacobras.humanreadable.HumanReadable.number
+import kotlin.time.Clock
 import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 /**
  * A collection of data formatting utilities.
@@ -24,6 +25,7 @@ public object HumanReadable {
      * @param instant The [Instant] to format.
      * @return a formatted string
      */
+    @OptIn(ExperimentalTime::class)
     public fun timeAgo(
         instant: Instant,
         baseInstant: Instant = Clock.System.now()

--- a/src/commonMain/kotlin/nl/jacobras/humanreadable/HumanReadableRelativeTime.kt
+++ b/src/commonMain/kotlin/nl/jacobras/humanreadable/HumanReadableRelativeTime.kt
@@ -1,7 +1,8 @@
 package nl.jacobras.humanreadable
 
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 import HumanReadableRes as Res
-import kotlinx.datetime.Instant
 
 /**
  * Returns the difference between [baseInstant] and [instant], in human-readable format.
@@ -10,6 +11,7 @@ import kotlinx.datetime.Instant
  * @param instant The [Instant] to compare with [baseInstant].
  * @param baseInstant The base/starting [Instant], usually "now".
  */
+@OptIn(ExperimentalTime::class)
 internal fun formatTimeAgo(
     instant: Instant,
     baseInstant: Instant

--- a/src/commonTest/kotlin/nl/jacobras/humanreadable/HumanReadableRelativeTimeTests.kt
+++ b/src/commonTest/kotlin/nl/jacobras/humanreadable/HumanReadableRelativeTimeTests.kt
@@ -3,13 +3,14 @@ package nl.jacobras.humanreadable
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import io.github.skeptick.libres.LibresSettings
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlin.test.Test
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
-import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
+@OptIn(ExperimentalTime::class)
 class HumanReadableRelativeTimeTests {
 
     init {

--- a/src/commonTest/kotlin/nl/jacobras/humanreadable/localized/LocalizedTests.kt
+++ b/src/commonTest/kotlin/nl/jacobras/humanreadable/localized/LocalizedTests.kt
@@ -3,18 +3,20 @@ package nl.jacobras.humanreadable.localized
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import io.github.skeptick.libres.LibresSettings
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import nl.jacobras.humanreadable.DistanceUnit
 import nl.jacobras.humanreadable.HumanReadable
 import kotlin.test.Test
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 /**
  * Smoke test that verifies all supported languages have working plural formatting.
  */
+@OptIn(ExperimentalTime::class)
 class LocalizedTests {
 
     private val now: Instant = Clock.System.now()


### PR DESCRIPTION
Hi, first time contributing here, let me know if anything should be changed to meet your standards 🙂 

As mentioned in #148, `kotlinx.datetime` version `0.7.0` drops the `Clock` and `Instant` implementations in favour of `kotlin.time.Clock` and `kotlin.time.Instant`. 

This is a fairly small change so I thought I would just open a PR to try it out, but for now it requires opting in for `ExperimentalTime` for methods that use these classes so I don't know if it's wise making this change right away.

Another possibility would be to use `0.7.0-0.6.x-compat` version of `kotlinx.datetime` until `Instant` and `Clock` are no long in experimental state. Or just simply wait it out 🤷 

Let me know what you think!