### PR TITLE
Add Czech future tense translation

### DIFF
--- a/src/commonMain/libres/strings/time_units_cs.xml
+++ b/src/commonMain/libres/strings/time_units_cs.xml
@@ -10,6 +10,11 @@
         <item quantity="few">sekundami</item>
         <item quantity="other">sekundami</item>
     </plurals>
+    <plurals name="seconds_future">
+        <item quantity="one">sekundu</item>
+        <item quantity="few">sekundy</item>
+        <item quantity="other">sekund</item>
+    </plurals>
     <plurals name="minutes">
         <item quantity="one">minuta</item>
         <item quantity="few">minuty</item>
@@ -20,6 +25,11 @@
         <item quantity="few">minutami</item>
         <item quantity="other">minutami</item>
     </plurals>
+    <plurals name="minutes_future">
+        <item quantity="one">minutu</item>
+        <item quantity="few">minuty</item>
+        <item quantity="other">minut</item>
+    </plurals>
     <plurals name="hours">
         <item quantity="one">hodina</item>
         <item quantity="few">hodiny</item>
@@ -29,6 +39,11 @@
         <item quantity="one">hodinou</item>
         <item quantity="few">hodinami</item>
         <item quantity="other">hodinami</item>
+    </plurals>
+    <plurals name="hours_future">
+        <item quantity="one">hodinu</item>
+        <item quantity="few">hodiny</item>
+        <item quantity="other">hodin</item>
     </plurals>
     <plurals name="days">
         <item quantity="one">den</item>

--- a/src/commonTest/kotlin/nl/jacobras/humanreadable/localized/LocalizedTests.kt
+++ b/src/commonTest/kotlin/nl/jacobras/humanreadable/localized/LocalizedTests.kt
@@ -20,6 +20,7 @@ import kotlin.time.Instant
 class LocalizedTests {
 
     private val now: Instant = Clock.System.now()
+    private val oneSecondFromNow = now + 1.seconds
     private val twoSeconds = 2.seconds
     private val twoSecondsAgo = now - twoSeconds
     private val twoSecondsFromNow = now + twoSeconds
@@ -54,11 +55,14 @@ class LocalizedTests {
         assertThat(HumanReadable.number(1_000_000.34, decimals = 2)).isEqualTo("1 000 000,34")
         assertThat(HumanReadable.number(-4.34, decimals = 2)).isEqualTo("-4,34")
 
+        assertThat(HumanReadable.timeAgo(oneSecondFromNow, baseInstant = now)).isEqualTo("za 1 sekundu")
         assertThat(HumanReadable.timeAgo(twoSecondsAgo, baseInstant = now)).isEqualTo("před 2 sekundami")
         assertThat(HumanReadable.timeAgo(oneMinuteAgo, baseInstant = now)).isEqualTo("před 1 minutou")
+        assertThat(HumanReadable.timeAgo(oneMinuteFromNow, baseInstant = now)).isEqualTo("za 1 minutu")
         assertThat(HumanReadable.timeAgo(twoMinutesAgo, baseInstant = now)).isEqualTo("před 2 minutami")
         assertThat(HumanReadable.timeAgo(now - 20.minutes, baseInstant = now)).isEqualTo("před 20 minutami")
         assertThat(HumanReadable.timeAgo(oneHourAgo, baseInstant = now)).isEqualTo("před 1 hodinou")
+        assertThat(HumanReadable.timeAgo(oneHourFromNow, baseInstant = now)).isEqualTo("za 1 hodinu")
         assertThat(HumanReadable.duration(oneDay)).isEqualTo("1 den")
         assertThat(HumanReadable.duration(twoDays)).isEqualTo("2 dny")
         assertThat(HumanReadable.timeAgo(oneDayAgo, baseInstant = now)).isEqualTo("před 1 dnem")


### PR DESCRIPTION
Hi, thank you for your awesome KMP library. 

I noticed some of the time strings are not correct in the future tense in Czech. For example `in 1 hour` should be `za 1 hodinu`, but was `za 1 hodina`. It was the same with seconds and minutes.

Since it is a fairly small change, I created this PR directly - I added support for the future tense in Czech where appropriate (days, weeks etc. are working fine as is) and added some tests for the previously wrong examples.

Let me know if I missed something.