### PR TITLE
Fix incorrect formatting of negative numbers

### DIFF
--- a/src/commonMain/kotlin/nl/jacobras/humanreadable/HumanReadableNumber.kt
+++ b/src/commonMain/kotlin/nl/jacobras/humanreadable/HumanReadableNumber.kt
@@ -12,12 +12,22 @@ internal fun Double.formatNumber(
     val rounded = formatWithDecimals(decimals)
     val parts = rounded.split('.')
 
+    val integerPart = parts[0]
+    // Check is Negative
+    val isNegative = integerPart.startsWith("-")
+
+    // If Negative Then drop first letter
+    val numberPart = if (isNegative) integerPart.substring(1) else integerPart
+
     // Format the integer part
-    val formattedIntegerPart = parts[0]
+    val formattedNumberPart = numberPart
         .reversed()
         .chunked(3)
         .joinToString(groupSeparator)
         .reversed()
+
+    val formattedIntegerPart = if (isNegative) "-$formattedNumberPart" else formattedNumberPart
+
 
     // Format the decimal part
     val decimalPart = if (parts.size > 1) parts[1] else ""

--- a/src/commonTest/kotlin/nl/jacobras/humanreadable/HumanReadableNumberEdgeCaseTests.kt
+++ b/src/commonTest/kotlin/nl/jacobras/humanreadable/HumanReadableNumberEdgeCaseTests.kt
@@ -15,4 +15,10 @@ class HumanReadableNumberEdgeCaseTests {
         assertThat(HumanReadable.number(0.04, decimals = 2)).isEqualTo("0.04")
         assertThat(HumanReadable.number(00000.00004, decimals = 3)).isEqualTo("0.000")
     }
+
+    @Test
+    fun negativeNumber() {
+        assertThat(HumanReadable.number(-123456)).isEqualTo("-123,456")
+        assertThat(HumanReadable.number(-123)).isEqualTo("-123")
+    }
 }


### PR DESCRIPTION
The grouping separator was incorrectly applied to negative numbers. This change ensures that the minus sign is not included in the grouping logic, resulting in the correct format for negative values (e.g., `-123,456` instead of `-,123,456`).

A regression test for negative numbers has also been added.