### PR TITLE
fix(french): Change decimal symbol from `.` to `,`

### DIFF
--- a/src/commonMain/libres/strings/number_units_fr.xml
+++ b/src/commonMain/libres/strings/number_units_fr.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="groupSeparator"> </string>
-    <string name="decimalSymbol">.</string>
+    <string name="decimalSymbol">,</string>
 </resources>

--- a/src/commonTest/kotlin/nl/jacobras/humanreadable/localized/LocalizedTests.kt
+++ b/src/commonTest/kotlin/nl/jacobras/humanreadable/localized/LocalizedTests.kt
@@ -142,10 +142,10 @@ class LocalizedTests {
         LibresSettings.languageCode = "fr"
         assertThat(HumanReadable.duration(2.seconds)).isEqualTo("2 secondes")
 
-        assertThat(HumanReadable.number(1_000_000.34, decimals = 2)).isEqualTo("1 000 000.34")
-        assertThat(HumanReadable.number(-4.34, decimals = 2)).isEqualTo("-4.34")
+        assertThat(HumanReadable.number(1_000_000.34, decimals = 2)).isEqualTo("1 000 000,34")
+        assertThat(HumanReadable.number(-4.34, decimals = 2)).isEqualTo("-4,34")
 
-        assertThat(HumanReadable.fileSize(2_000_000, decimals = 1)).isEqualTo("1.9 Mo")
+        assertThat(HumanReadable.fileSize(2_000_000, decimals = 1)).isEqualTo("1,9 Mo")
     }
 
     @Test


### PR DESCRIPTION
Hi!
Based on the unicode [number formatting chart for french](https://www.unicode.org/cldr/cldr-aux/charts/30/verify/numbers/fr.html) the decimal separator is a comma instead of a period

Close https://github.com/jacobras/Human-Readable/issues/173